### PR TITLE
fix(ArticlePreview): was exporting ArticleActions instead of ArticleP…

### DIFF
--- a/src/components/ArticlePreview.js
+++ b/src/components/ArticlePreview.js
@@ -77,4 +77,4 @@ const ArticlePreview = props => {
   );
 }
 
-export default connect(() => ({}), mapDispatchToProps)(ArticleActions);
+export default connect(() => ({}), mapDispatchToProps)(ArticlePreview);


### PR DESCRIPTION
The ArticlePreview component was exporting ArticleActions which caused errors directly after cloning the repo.